### PR TITLE
Fix 502 on forrest.rainierserver.com (origin port mismatch)

### DIFF
--- a/infra/caddy/Caddyfile
+++ b/infra/caddy/Caddyfile
@@ -1,4 +1,4 @@
-:8080 {
+:8090 {
   root * /srv
   file_server
   encode gzip zstd

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -3,19 +3,10 @@ services:
     image: caddy:2
     container_name: forrest-site
     restart: unless-stopped
+    # Port must match the cloudflared ingress rule for forrest.rainierserver.com
+    # (host-level /etc/cloudflared/config.yml -> http://localhost:8090).
     ports:
-      - "127.0.0.1:8080:8080"
+      - "127.0.0.1:8090:8090"
     volumes:
       - ./caddy/Caddyfile:/etc/caddy/Caddyfile:ro
       - ../apps/site/dist:/srv:ro
-
-  tunnel:
-    image: cloudflare/cloudflared:latest
-    container_name: forrest-site-tunnel
-    restart: unless-stopped
-    depends_on: [site]
-    command: tunnel --config /etc/cloudflared/config.yml run
-    environment:
-      - TUNNEL_TOKEN=${CLOUDFLARED_TUNNEL_TOKEN}
-    volumes:
-      - ./cloudflared/config.yml:/etc/cloudflared/config.yml:ro


### PR DESCRIPTION
## Problem

`forrest.rainierserver.com` returned **502**. DNS and the Cloudflare Tunnel were both healthy — `cloudflared.service` had been up for two weeks with a good connection. The break was at the last hop:

```
Unable to reach the origin service ... dial tcp 127.0.0.1:8090: connect: connection refused
```

The host-level cloudflared ingress routes the hostname to `http://localhost:8090`, but `infra/docker-compose.yml` published **8080**. Nothing ever listened on 8090, so Cloudflare served a 502. The `forrest-site` container had never been created on Rainier.

8080 is also already bound by `spoker-caddy` on `0.0.0.0`, so the old mapping could not have bound even if the ports had matched.

## Changes

- Caddy listens on `:8090`; compose publishes `127.0.0.1:8090:8090`, with a comment tying the port to the ingress rule so the two don't drift again.
- Drop the `tunnel` service. It duplicated the host-level cloudflared and referenced `infra/cloudflared/config.yml` and a `CLOUDFLARED_TUNNEL_TOKEN` from `infra/.env` — neither exists, so `docker compose up` failed on the missing variable.

## Verification

Deployed and confirmed live before opening this PR:

- local origin `127.0.0.1:8090` → 200
- public site → 200
- `/`, `/about/`, `/adventures/`, `/portfolio/`, `/writing/`, `/photography/`, `/music/`, `/youtube/`, `/resume/` → all 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)