### PR TITLE
Add push-to-main deploy pipeline and PR CI (#2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,13 @@ jobs:
         working-directory: apps/site
         run: npm ci
 
+      # tsc needs .astro/types.d.ts to resolve the `astro:content` import in
+      # src/content.config.ts. That directory is gitignored and generated, so
+      # on a clean checkout typecheck fails with TS2307 unless we sync first.
+      - name: Generate content types
+        working-directory: apps/site
+        run: npx astro sync
+
       - name: Typecheck
         working-directory: apps/site
         run: npm run typecheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: CI
+
+# Validates PRs before they can land on main. Deploy runs its own typecheck
+# and build on push, so this deliberately does not trigger on main -- that
+# would just duplicate the deploy job's work.
+on:
+  pull_request:
+    branches: ["main"]
+  workflow_dispatch:
+
+# SECURITY: must stay on ubuntu-latest, never [self-hosted, rainier].
+# This repo is public and this workflow has a pull_request trigger, so a fork's
+# PR runs here before any review. On the self-hosted runner that would mean
+# arbitrary code executing on a machine inside the home network. Branch
+# protection does not prevent this -- fork PRs never touch main.
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: apps/site/package-lock.json
+
+      - name: Install
+        working-directory: apps/site
+        run: npm ci
+
+      - name: Typecheck
+        working-directory: apps/site
+        run: npm run typecheck
+
+      - name: Build
+        working-directory: apps/site
+        run: npm run build
+
+      # Same guard the deploy workflow applies, so a content or routing
+      # regression surfaces in review rather than at publish time.
+      - name: Verify build output
+        working-directory: apps/site
+        run: |
+          set -euo pipefail
+          test -s dist/index.html
+          pages=$(find dist -name '*.html' | wc -l)
+          echo "built $pages html pages"
+          test "$pages" -ge 10
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,67 @@
+name: Build & Deploy (forrest.rainierserver.com)
+
+# Runs on the self-hosted runner on Rainier, so the build and the web root are
+# on the same machine -- no SSH, no secrets, no inbound ports.
+#
+# SECURITY: this repo is public. Never add a `pull_request` trigger here.
+# A fork's PR would execute arbitrary code on the runner inside the home
+# network. `push` to main and manual dispatch both require write access.
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+concurrency:
+  group: forrest-site-deploy
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: [self-hosted, rainier]
+    env:
+      WEB_ROOT: /srv/www/forrestmorrisey.com
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: apps/site/package-lock.json
+
+      - name: Install
+        working-directory: apps/site
+        run: npm ci
+
+      - name: Typecheck
+        working-directory: apps/site
+        run: npm run typecheck
+
+      - name: Build
+        working-directory: apps/site
+        run: npm run build
+
+      # rsync --delete would happily empty the live site if a build silently
+      # produced nothing, so refuse to publish a dist that looks wrong.
+      - name: Verify build output
+        run: |
+          set -euo pipefail
+          test -s apps/site/dist/index.html
+          pages=$(find apps/site/dist -name '*.html' | wc -l)
+          echo "built $pages html pages"
+          test "$pages" -ge 10
+
+      - name: Publish to web root
+        run: |
+          set -euo pipefail
+          rsync -a --delete apps/site/dist/ "$WEB_ROOT/"
+
+      - name: Smoke test origin
+        run: |
+          set -euo pipefail
+          code=$(curl -sS -o /dev/null -w '%{http_code}' \
+            --retry 5 --retry-delay 2 --retry-all-errors \
+            http://127.0.0.1:8090/)
+          echo "origin returned $code"
+          test "$code" = "200"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,18 +11,27 @@ on:
     branches: ["main"]
   workflow_dispatch:
 
+# Never cancel a deploy mid-flight: the publish step rsyncs --delete into the
+# live web root, and killing it there leaves the site in a mixed state until
+# the next run finishes. Queue instead.
 concurrency:
   group: forrest-site-deploy
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   deploy:
     runs-on: [self-hosted, rainier]
+    permissions:
+      contents: read
     env:
       WEB_ROOT: /srv/www/forrestmorrisey.com
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          # This runner is on the home network and npm lifecycle scripts run
+          # here; don't leave a credential in .git/config for them to find.
+          persist-credentials: false
 
       - uses: actions/setup-node@v4
         with:
@@ -33,6 +42,14 @@ jobs:
       - name: Install
         working-directory: apps/site
         run: npm ci
+
+      # Required, not just belt-and-braces: tsc needs .astro/types.d.ts for the
+      # `astro:content` import, and actions/checkout runs `git clean -ffdx`,
+      # which wipes that gitignored directory from any previous run on this
+      # persistent runner. Without this the deploy can never reach Publish.
+      - name: Generate content types
+        working-directory: apps/site
+        run: npx astro sync
 
       - name: Typecheck
         working-directory: apps/site

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -9,4 +9,7 @@ services:
       - "127.0.0.1:8090:8090"
     volumes:
       - ./caddy/Caddyfile:/etc/caddy/Caddyfile:ro
-      - ../apps/site/dist:/srv:ro
+      # Served content is the deploy web root on the host, written by the
+      # self-hosted runner (see .github/workflows/deploy.yml). Deliberately not
+      # the git working copy -- production must not depend on a local build.
+      - /srv/www/forrestmorrisey.com:/srv:ro

--- a/infra/setup-runner.sh
+++ b/infra/setup-runner.sh
@@ -47,7 +47,13 @@ sudo chmod 755 "$WEB_ROOT"
 
 # Seed from the current local build so the site never serves an empty dir
 # between the compose change and the first pipeline run.
-if [ -s "$SITE_DIR/dist/index.html" ]; then
+#
+# Only when the web root is empty. Re-running this script later from a stale
+# working copy must not rsync --delete an old build over live content that the
+# pipeline has since published.
+if [ -s "$WEB_ROOT/index.html" ]; then
+  log "web root already populated, leaving it alone"
+elif [ -s "$SITE_DIR/dist/index.html" ]; then
   log "seeding web root from existing local build"
   sudo rsync -a --delete "$SITE_DIR/dist/" "$WEB_ROOT/"
   sudo chown -R "$RUNNER_USER:$RUNNER_USER" "$WEB_ROOT"
@@ -65,10 +71,14 @@ else
   sudo mkdir -p "$RUNNER_DIR"
   sudo chown "$RUNNER_USER:$RUNNER_USER" "$RUNNER_DIR"
   tarball="actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz"
-  sudo -u "$RUNNER_USER" curl -fsSL -o "/tmp/$tarball" \
+  # Stage inside the runner dir, not /tmp. The download runs as $RUNNER_USER,
+  # and /tmp is sticky-bit, so removing it afterwards as the invoking user
+  # fails with EPERM -- which `rm -f` does not suppress and `set -e` turns into
+  # an abort partway through the install.
+  sudo -u "$RUNNER_USER" curl -fsSL -o "$RUNNER_DIR/$tarball" \
     "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/${tarball}"
-  sudo -u "$RUNNER_USER" tar xzf "/tmp/$tarball" -C "$RUNNER_DIR"
-  rm -f "/tmp/$tarball"
+  sudo -u "$RUNNER_USER" tar xzf "$RUNNER_DIR/$tarball" -C "$RUNNER_DIR"
+  sudo -u "$RUNNER_USER" rm -f "$RUNNER_DIR/$tarball"
   log "installing runner OS dependencies"
   sudo "$RUNNER_DIR/bin/installdependencies.sh"
 fi
@@ -104,17 +114,29 @@ else
   log "installing runner as a systemd service"
   (cd "$RUNNER_DIR" && sudo ./svc.sh install "$RUNNER_USER")
 fi
-(cd "$RUNNER_DIR" && sudo ./svc.sh start || true)
+# Not `|| true`: if the service will not start there is nothing to deploy to,
+# and the operator needs to see that now rather than after pushing to main and
+# watching a job queue forever.
+(cd "$RUNNER_DIR" && sudo ./svc.sh start)
 
 # --- 6. point Caddy at the new web root ------------------------------------
 log "recreating Caddy container against $WEB_ROOT"
-(cd "$INFRA_DIR" && docker compose up -d)
+# --remove-orphans clears the retired forrest-site-tunnel container. Left
+# running it would be a second cloudflared connector for the same hostname,
+# pointed at the old :8080 origin, causing intermittent 502s.
+(cd "$INFRA_DIR" && docker compose up -d --remove-orphans)
 
 # --- 7. verify -------------------------------------------------------------
 log "verifying"
 sleep 3
 code="$(curl -sS -o /dev/null -w '%{http_code}' --retry 5 --retry-delay 2 --retry-all-errors http://127.0.0.1:8090/ || true)"
 echo "local origin:  HTTP $code"
+# The origin is the one thing this script is responsible for. Fail loudly
+# rather than printing "Done." over a broken serve.
+if [ "$code" != "200" ]; then
+  echo "ERROR: origin is not serving (expected 200, got ${code:-no response})" >&2
+  exit 1
+fi
 echo "public site:   HTTP $(curl -sS -o /dev/null -w '%{http_code}' -m 15 https://forrest.rainierserver.com/ || true)"
 (cd "$RUNNER_DIR" && sudo ./svc.sh status || true)
 

--- a/infra/setup-runner.sh
+++ b/infra/setup-runner.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+#
+# One-time host setup for the forrestmorrisey.com deploy pipeline on Rainier.
+#
+#   ./infra/setup-runner.sh
+#
+# Run as your normal user (needs sudo, and `gh` already authenticated).
+# Idempotent: safe to re-run.
+#
+# Creates:
+#   - a `deploy` system user that owns the web root and runs the runner
+#   - /srv/www/forrestmorrisey.com, seeded from the current local build
+#   - a GitHub Actions self-hosted runner at /opt/actions-runner, labelled
+#     `rainier`, installed as a systemd service
+#   - recreates the Caddy container to serve the new web root
+#
+set -euo pipefail
+
+REPO="fmorrisey/forrestmorrisey.com"
+WEB_ROOT="/srv/www/forrestmorrisey.com"
+RUNNER_DIR="/opt/actions-runner"
+RUNNER_USER="deploy"
+INFRA_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SITE_DIR="$(cd "$INFRA_DIR/../apps/site" && pwd)"
+
+log() { printf '\n\033[1;32m==>\033[0m %s\n' "$1"; }
+
+# --- preflight -------------------------------------------------------------
+command -v gh >/dev/null || { echo "gh not found"; exit 1; }
+gh auth status >/dev/null 2>&1 || { echo "gh not authenticated -- run: gh auth login"; exit 1; }
+command -v rsync >/dev/null || { echo "rsync not found -- sudo apt install rsync"; exit 1; }
+sudo -v
+
+# --- 1. deploy user --------------------------------------------------------
+if id "$RUNNER_USER" >/dev/null 2>&1; then
+  log "user '$RUNNER_USER' already exists, skipping"
+else
+  log "creating '$RUNNER_USER' user"
+  sudo adduser --system --group --shell /bin/bash --home "/home/$RUNNER_USER" "$RUNNER_USER"
+fi
+
+# --- 2. web root -----------------------------------------------------------
+log "creating web root at $WEB_ROOT"
+sudo mkdir -p "$WEB_ROOT"
+sudo chown -R "$RUNNER_USER:$RUNNER_USER" "$WEB_ROOT"
+sudo chmod 755 "$WEB_ROOT"
+
+# Seed from the current local build so the site never serves an empty dir
+# between the compose change and the first pipeline run.
+if [ -s "$SITE_DIR/dist/index.html" ]; then
+  log "seeding web root from existing local build"
+  sudo rsync -a --delete "$SITE_DIR/dist/" "$WEB_ROOT/"
+  sudo chown -R "$RUNNER_USER:$RUNNER_USER" "$WEB_ROOT"
+else
+  echo "WARNING: no local build at $SITE_DIR/dist -- web root will be empty"
+  echo "         until the first pipeline run. Build with: cd apps/site && npm run build"
+fi
+
+# --- 3. runner download ----------------------------------------------------
+if [ -x "$RUNNER_DIR/run.sh" ]; then
+  log "runner already installed at $RUNNER_DIR, skipping download"
+else
+  RUNNER_VERSION="$(gh api repos/actions/runner/releases/latest --jq .tag_name | sed 's/^v//')"
+  log "installing actions runner v$RUNNER_VERSION"
+  sudo mkdir -p "$RUNNER_DIR"
+  sudo chown "$RUNNER_USER:$RUNNER_USER" "$RUNNER_DIR"
+  tarball="actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz"
+  sudo -u "$RUNNER_USER" curl -fsSL -o "/tmp/$tarball" \
+    "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/${tarball}"
+  sudo -u "$RUNNER_USER" tar xzf "/tmp/$tarball" -C "$RUNNER_DIR"
+  rm -f "/tmp/$tarball"
+  log "installing runner OS dependencies"
+  sudo "$RUNNER_DIR/bin/installdependencies.sh"
+fi
+
+# --- 4. register -----------------------------------------------------------
+if [ -f "$RUNNER_DIR/.runner" ]; then
+  log "runner already registered, skipping"
+else
+  log "registering runner with $REPO"
+  # Short-lived (1h) registration token, fetched fresh so it can't go stale.
+  REG_TOKEN="$(gh api -X POST "repos/$REPO/actions/runners/registration-token" --jq .token)"
+  sudo -u "$RUNNER_USER" "$RUNNER_DIR/config.sh" \
+    --unattended --replace \
+    --url "https://github.com/$REPO" \
+    --token "$REG_TOKEN" \
+    --name rainier \
+    --labels rainier \
+    --work _work
+fi
+
+# --- 5. systemd service ----------------------------------------------------
+if systemctl list-units --all --type=service | grep -q 'actions.runner.*\.service'; then
+  log "runner service already installed"
+else
+  log "installing runner as a systemd service"
+  sudo "$RUNNER_DIR/svc.sh" install "$RUNNER_USER"
+fi
+sudo "$RUNNER_DIR/svc.sh" start || true
+
+# --- 6. point Caddy at the new web root ------------------------------------
+log "recreating Caddy container against $WEB_ROOT"
+(cd "$INFRA_DIR" && docker compose up -d)
+
+# --- 7. verify -------------------------------------------------------------
+log "verifying"
+sleep 3
+code="$(curl -sS -o /dev/null -w '%{http_code}' --retry 5 --retry-delay 2 --retry-all-errors http://127.0.0.1:8090/ || true)"
+echo "local origin:  HTTP $code"
+echo "public site:   HTTP $(curl -sS -o /dev/null -w '%{http_code}' -m 15 https://forrest.rainierserver.com/ || true)"
+sudo "$RUNNER_DIR/svc.sh" status || true
+
+cat <<'EOF'
+
+Done. Remaining manual step (GitHub web UI, 30 seconds):
+
+  Settings -> Actions -> General -> Fork pull request workflows
+    set "Require approval for all outside collaborators"
+
+  This repo is PUBLIC. The deploy workflow has no pull_request trigger, so
+  forks cannot reach the runner today -- this setting keeps that true if a
+  PR-triggered workflow is ever added.
+
+Then push to main (or run the workflow manually) to deploy.
+EOF

--- a/infra/setup-runner.sh
+++ b/infra/setup-runner.sh
@@ -57,7 +57,7 @@ else
 fi
 
 # --- 3. runner download ----------------------------------------------------
-if [ -x "$RUNNER_DIR/run.sh" ]; then
+if [ -x "$RUNNER_DIR/bin/Runner.Listener" ]; then
   log "runner already installed at $RUNNER_DIR, skipping download"
 else
   RUNNER_VERSION="$(gh api repos/actions/runner/releases/latest --jq .tag_name | sed 's/^v//')"
@@ -80,23 +80,31 @@ else
   log "registering runner with $REPO"
   # Short-lived (1h) registration token, fetched fresh so it can't go stale.
   REG_TOKEN="$(gh api -X POST "repos/$REPO/actions/runners/registration-token" --jq .token)"
-  sudo -u "$RUNNER_USER" "$RUNNER_DIR/config.sh" \
+  # config.sh resolves ./bin/... relative to the working directory, so it must
+  # run from the runner root or it emits spurious ldd errors.
+  (cd "$RUNNER_DIR" && sudo -u "$RUNNER_USER" ./config.sh \
     --unattended --replace \
     --url "https://github.com/$REPO" \
     --token "$REG_TOKEN" \
     --name rainier \
     --labels rainier \
-    --work _work
+    --work _work)
 fi
 
 # --- 5. systemd service ----------------------------------------------------
-if systemctl list-units --all --type=service | grep -q 'actions.runner.*\.service'; then
+# Check this runner's own .service marker, not `systemctl | grep actions.runner`:
+# Rainier also hosts a runner for Spokerv2, and a broad match would see that
+# one and silently skip installing this service.
+#
+# svc.sh, like config.sh, must be invoked from the runner root -- otherwise it
+# fails with "Must run from runner root or install is corrupt".
+if [ -f "$RUNNER_DIR/.service" ]; then
   log "runner service already installed"
 else
   log "installing runner as a systemd service"
-  sudo "$RUNNER_DIR/svc.sh" install "$RUNNER_USER"
+  (cd "$RUNNER_DIR" && sudo ./svc.sh install "$RUNNER_USER")
 fi
-sudo "$RUNNER_DIR/svc.sh" start || true
+(cd "$RUNNER_DIR" && sudo ./svc.sh start || true)
 
 # --- 6. point Caddy at the new web root ------------------------------------
 log "recreating Caddy container against $WEB_ROOT"
@@ -108,7 +116,7 @@ sleep 3
 code="$(curl -sS -o /dev/null -w '%{http_code}' --retry 5 --retry-delay 2 --retry-all-errors http://127.0.0.1:8090/ || true)"
 echo "local origin:  HTTP $code"
 echo "public site:   HTTP $(curl -sS -o /dev/null -w '%{http_code}' -m 15 https://forrest.rainierserver.com/ || true)"
-sudo "$RUNNER_DIR/svc.sh" status || true
+(cd "$RUNNER_DIR" && sudo ./svc.sh status || true)
 
 cat <<'EOF'
 


### PR DESCRIPTION
Closes #2

Stacked on #8 — base retargets to `main` automatically once that merges.

## Problem

Production served `apps/site/dist` bind-mounted from the git working copy, so the live site depended on someone remembering to run a local build. That is how a Feb 15 build ended up serving Feb 16 content.

## Why a self-hosted runner instead of SSH

`doc/DeploymentPipelinePlan.md` assumed GitHub Actions would SSH to Rainier. That can't work as written: Rainier is reachable only over Tailscale (`100.114.215.12`), and a GitHub-hosted runner can't reach a `100.x` address without joining the tailnet. The alternatives were port-forwarding SSH to a residential IP, or Tailscale-in-Actions.

A runner on Rainier polls outbound instead, which removes the problem entirely — **no SSH, no deploy key, no inbound ports, and none of the five `RAINIER_*` secrets** the original plan required.

## Changes

- **`.github/workflows/deploy.yml`** — build → typecheck → publish → smoke test, on push to `main`. Single job, since build and web root now share a machine.
- **`.github/workflows/ci.yml`** — install → typecheck → build on every PR. Gives the `typecheck` script something that actually runs it.
- **`infra/docker-compose.yml`** — serves `/srv/www/forrestmorrisey.com` instead of the working copy, decoupling production from any local checkout.
- **`infra/setup-runner.sh`** — idempotent one-time host setup: `deploy` user, web root seeded from the current build to avoid a serving gap, runner install, registration, systemd service.

## Guards worth reviewing

- **Publish is gated on build sanity.** `rsync --delete` would empty the live site if a build silently produced nothing, so it refuses unless `index.html` is non-empty and ≥10 HTML pages exist (currently 30).
- **Smoke test after publish** — a broken deploy goes red instead of failing silently.
- **CI is pinned to `ubuntu-latest`, never the self-hosted runner.** This repo is public and `ci.yml` has a `pull_request` trigger, so a fork's PR runs before any review; on the Rainier runner that would be arbitrary code executing inside the home network. The `main` ruleset does **not** mitigate this — fork PRs never touch `main`. The reasoning is in a comment above `jobs:` so it survives future edits.
- **`deploy.yml` deliberately has no `pull_request` trigger**, for the same reason.

## Verification

Runner is live on Rainier and idle:

```
{"name":"rainier","status":"online","busy":false,
 "labels":["self-hosted","Linux","X64","rainier"]}
```

Caddy switched to the new web root, read-only:

```
/srv/www/forrestmorrisey.com -> /srv (rw=false)
```

Site confirmed 200 after the switch. Merging this is the first end-to-end test of the pipeline.

## Follow-ups (not in this PR)

- Add `build` as a required status check to `Main_Branch_Protection_v1` — possible only after CI runs once and GitHub learns the check name. Until then the ruleset requires review but tolerates a red run.
- Settings → Actions → General → Fork pull request workflows → "Require approval for all outside collaborators".

🤖 Generated with [Claude Code](https://claude.com/claude-code)