### PR TITLE
SEO foundations: site URL, canonicals, sitemap, robots.txt

### DIFF
--- a/apps/site/astro.config.mjs
+++ b/apps/site/astro.config.mjs
@@ -1,5 +1,19 @@
 // @ts-check
 import { defineConfig } from 'astro/config';
+import sitemap from '@astrojs/sitemap';
 
-// https://astro.build/config
-export default defineConfig({});
+// The canonical home of this site. Squarespace still serves this domain until
+// the cutover, and that is deliberate: canonical URLs and the sitemap should
+// describe the site's final home, not the staging origin it happens to be
+// served from today. Pointing canonicals at forrestmorrisey.com also keeps the
+// staging host from competing with the live site in search results, and means
+// nothing here has to change on cutover day.
+//
+// Override for a build that should describe a different origin:
+//   SITE_URL=https://forrest.rainierserver.com npm run build
+const SITE_URL = process.env.SITE_URL ?? 'https://forrestmorrisey.com';
+
+export default defineConfig({
+  site: SITE_URL,
+  integrations: [sitemap()],
+});

--- a/apps/site/package-lock.json
+++ b/apps/site/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "forrestmorrisey.com",
       "dependencies": {
+        "@astrojs/sitemap": "^3.7.3",
         "astro": "^5.17.1",
         "zod": "^3.23.8"
       },
@@ -66,6 +67,26 @@
       },
       "engines": {
         "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+      }
+    },
+    "node_modules/@astrojs/sitemap": {
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.7.3.tgz",
+      "integrity": "sha512-f8euLVsyeAmAkSm/1M2Kb8sL8byQmfgbvBNaHFItCheTj/IpiJYSEWVcqDHZ/yEHxiS7+w87mQkzwZaPHmk5GA==",
+      "license": "MIT",
+      "dependencies": {
+        "sitemap": "^9.0.0",
+        "stream-replace-string": "^2.0.0",
+        "zod": "^4.3.6"
+      }
+    },
+    "node_modules/@astrojs/sitemap/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@astrojs/telemetry": {
@@ -1520,10 +1541,18 @@
       "version": "20.19.33",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.33.tgz",
       "integrity": "sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/sax": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.7.tgz",
+      "integrity": "sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/unist": {
@@ -1648,6 +1677,12 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -4258,6 +4293,40 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
     },
+    "node_modules/sitemap": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-9.0.1.tgz",
+      "integrity": "sha512-S6hzjGJSG3d6if0YoF5kTyeRJvia6FSTBroE5fQ0bu1QNxyJqhhinfUsXi9fH3MgtXODWvwo2BDyQSnhPQ88uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^24.9.2",
+        "@types/sax": "^1.2.1",
+        "arg": "^5.0.0",
+        "sax": "^1.4.1"
+      },
+      "bin": {
+        "sitemap": "dist/esm/cli.js"
+      },
+      "engines": {
+        "node": ">=20.19.5",
+        "npm": ">=10.8.2"
+      }
+    },
+    "node_modules/sitemap/node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/sitemap/node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "license": "MIT"
+    },
     "node_modules/smol-toml": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.0.tgz",
@@ -4288,6 +4357,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/stream-replace-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stream-replace-string/-/stream-replace-string-2.0.0.tgz",
+      "integrity": "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==",
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "7.2.0",
@@ -4485,7 +4560,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unified": {

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -13,6 +13,7 @@
     "images:webp": "node scripts/optimize-images.mjs --webp"
   },
   "dependencies": {
+    "@astrojs/sitemap": "^3.7.3",
     "astro": "^5.17.1",
     "zod": "^3.23.8"
   },

--- a/apps/site/src/layouts/BaseLayout.astro
+++ b/apps/site/src/layouts/BaseLayout.astro
@@ -16,6 +16,10 @@ const {
 } = Astro.props;
 
 const currentPath = Astro.url.pathname;
+
+// Absolute canonical for this page, resolved against `site` in astro.config.mjs.
+// Setting `site` alone does not emit this tag -- it has to be rendered here.
+const canonicalURL = new URL(currentPath, Astro.site);
 ---
 <!doctype html>
 <html lang="en">
@@ -24,6 +28,7 @@ const currentPath = Astro.url.pathname;
     <meta name="viewport" content="width=device-width,initial-scale=1" />
     <title>{title}</title>
     {description ? <meta name="description" content={description} /> : null}
+    <link rel="canonical" href={canonicalURL.href} />
   </head>
   <body>
     <SiteHeader currentPath={currentPath} />

--- a/apps/site/src/pages/robots.txt.ts
+++ b/apps/site/src/pages/robots.txt.ts
@@ -1,0 +1,16 @@
+import type { APIRoute } from 'astro';
+
+// Generated rather than a static public/robots.txt so the Sitemap line always
+// matches whatever `site` is configured as, including a SITE_URL override.
+// A hardcoded file would silently drift on cutover.
+export const GET: APIRoute = ({ site }) => {
+  const body = `User-agent: *
+Allow: /
+
+Sitemap: ${new URL('sitemap-index.xml', site).href}
+`;
+
+  return new Response(body, {
+    headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+  });
+};


### PR DESCRIPTION
Closes #11

## Problem

`astro.config.mjs` was `defineConfig({})` — no `site` set. Consequences:

- no canonical URL on any of the 30 pages
- `@astrojs/sitemap` could not run (it requires `site`)
- `@astrojs/rss` blocked, which blocks #13
- no `robots.txt` anywhere in `dist/`

## Why `site` points at forrestmorrisey.com

That domain is still served by Squarespace until cutover, so pointing canonicals at it may look wrong. It isn't:

- Canonicals should describe the site's **final** home. Retrofitting them after search engines have indexed `forrest.rainierserver.com` is materially worse.
- It stops the staging origin competing with the live site in search results — the open question raised in #11, resolved without needing `X-Robots-Tag` plumbing in Caddy.
- Nothing has to change on cutover day.

`SITE_URL` overrides it for builds describing another origin.

## Changes

- **`astro.config.mjs`** — `site` (env-overridable) + `@astrojs/sitemap`
- **`src/layouts/BaseLayout.astro`** — renders `<link rel="canonical">`. Setting `site` alone does **not** emit this; it has to be in the template.
- **`src/pages/robots.txt.ts`** — generated endpoint, not a static `public/robots.txt`, so its `Sitemap:` line always tracks the configured `site` rather than drifting silently at cutover.

## Verification

```
typecheck            exit 0
build                30 pages
sitemap-index.xml    -> sitemap-0.xml, 30 <loc> entries
robots.txt           Sitemap: https://forrestmorrisey.com/sitemap-index.xml
canonical tags       30/30 pages, 0 missing
SITE_URL override    rewrites canonicals + sitemap + robots, both directions
```

## Notes

- `npm audit` reports 13 vulnerabilities in the vite/astro dev dependency tree. All are Windows-specific dev-server issues, pre-existing and unrelated to this change; not touched here to keep the diff scoped.
- Open Graph / Twitter card tags are a natural follow-up but out of scope for #11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)