### PR TITLE
Redirect legacy Squarespace URLs to their new routes

### DIFF
--- a/infra/caddy/Caddyfile
+++ b/infra/caddy/Caddyfile
@@ -1,5 +1,49 @@
 :8090 {
   root * /srv
+
+  # Legacy Squarespace URLs -> new routes.
+  #
+  # Wrapped in `route` so these are evaluated in the order written: the two
+  # specific /blog/<date>/<slug> post redirects must be tried before the
+  # /blog/* catch-all, or every post would land on the writing index.
+  #
+  # 301 (permanent) rather than 302: these moves are final, and search engines
+  # should transfer ranking to the new URLs. Verified list -- every path below
+  # currently 404s on the new site.
+  route {
+    redir /home / permanent
+
+    redir /services /contact/ permanent
+    redir /social-feeds /social/ permanent
+    redir /projects /portfolio/ permanent
+    redir /explore /adventures/ permanent
+    redir /iat-2020 /adventures/iat-2020/ permanent
+
+    # /browse and /photos were two Squarespace entry points to the same gallery
+    # landing; they collapse into one route here.
+    redir /browse /photography/ permanent
+    redir /photos /photography/ permanent
+    redir /portraits /photography/portraits/ permanent
+    redir /climatestrike /photography/climate-strike/ permanent
+    redir /latest /photography/highlights/ permanent
+
+    # Retired Squarespace pages: "UX / UI (Copy)" was a duplicate, and
+    # "New Gallery" was an empty orphan. Fold them into the nearest parent
+    # rather than 404 -- a live link should still land somewhere useful.
+    redir /ux-ui-1 /portfolio/ permanent
+    redir /new-gallery-1 /photography/ permanent
+
+    # Blog posts first, then the index, then everything else under /blog.
+    redir /blog/2020/5/15/the-journey-begins /writing/the-journey-begins/ permanent
+    redir /blog/2020/9/2/printhello-world /writing/print-hello-world/ permanent
+    redir /blog /writing/ permanent
+
+    # Catch-all for /blog/tag/* and /blog/category/*. Temporary: it sends
+    # taxonomy URLs to the writing index because the tag routes do not exist
+    # yet. Point these at the real tag pages once #17 lands.
+    redir /blog/* /writing/ permanent
+  }
+
   file_server
   encode gzip zstd
 


### PR DESCRIPTION
Closes #12

All 13 live Squarespace paths currently **404** on the new site. This adds 301s for every one.

## Why the list differs from the plan

I crawled the Squarespace sitemap rather than trusting the table in `doc/ContentMigrationPlan2.md`, which missed three live URLs:

- **`/photos`** — "Photos Home", a second entry point to the gallery landing
- **`/latest`** — titled "Highlights" → `/photography/highlights/`
- **`/home`** → `/`

## Why Caddy, not Astro `redirects`

Astro's `redirects` emits **meta-refresh HTML pages** in static output. These are real **301s**, so ranking transfers to the new URLs — which is the entire point of doing this before cutover.

## Ordering matters

Wrapped in `route` to guarantee evaluation order. The two specific `/blog/<date>/<slug>` post redirects must be tried **before** the `/blog/*` catch-all, or every post would land on the writing index instead of its own page. Verified below.

## Judgment calls

- **`/browse` and `/photos`** were two Squarespace entry points to the same gallery landing; both collapse into `/photography/`.
- **`/ux-ui-1`** ("UX / UI (Copy)", a duplicate) and **`/new-gallery-1`** (an empty orphan) fold into their nearest parent rather than 404 — a live link should still land somewhere useful. Say the word if you'd rather they 410.
- **`/blog/*` catch-all is temporary.** It sends tag and category URLs to the writing index because those routes don't exist yet. Repoint once #17 lands.

## Verification

Tested against a **throwaway container on `:8099`** with the real web root — the live site was never touched.

```
18/18  old paths  -> 301 with correct Location
       /blog/2020/5/15/the-journey-begins -> /writing/the-journey-begins/   (beats catch-all ✅)
       /blog/tag/Career                   -> /writing/                      (catch-all ✅)
13/13  targets    -> 200
       /about/ /resume/ /sitemap-index.xml /robots.txt /youtube/ /music/  unaffected
       Cache-Control: public, max-age=31536000, immutable  still applied
caddy validate: Valid configuration
```

## Note

These take effect on `docker compose up -d` (or a Caddy reload) — they're infra, not part of the site build, so merging alone won't apply them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)