### PR TITLE
Serve a branded fallback when the origin is unreachable

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,142 @@
+# Infrastructure
+
+forrestmorrisey.com is served from a single origin — Rainier — reached over a
+Cloudflare Tunnel.
+
+```
+Browser → Cloudflare → Tunnel → cloudflared (host) → :8090 Caddy → /srv/www/forrestmorrisey.com
+```
+
+| Path | What it is |
+|---|---|
+| `docker-compose.yml` | The Caddy container serving the deployed site on `127.0.0.1:8090`. |
+| `caddy/Caddyfile` | Static file serving, cache headers, and the legacy Squarespace redirects. |
+| `fallback/` | Static page shown when Rainier is unreachable. See below. |
+| `worker/` | Cloudflare Worker implementing the failover. See below. |
+
+Caddy serves `/srv/www/forrestmorrisey.com`, written by the self-hosted runner —
+deliberately not a local build, so production never depends on someone's working
+copy.
+
+---
+
+# Static Fallback & Social Redirect
+
+Tracks [issue #5](https://github.com/fmorrisey/forrestmorrisey.com/issues/5).
+
+When Rainier is down, Cloudflare serves its own error page (1033, or a 52x).
+This replaces that with a branded page pointing visitors at GitHub and LinkedIn,
+and gets out of the way the moment the origin returns.
+
+This is graceful failure, not uptime. Nothing here makes the site more
+available; it makes the unavailable case presentable.
+
+```
+Browser → Worker ──try──→ Rainier via Tunnel      (healthy: response passes through)
+                 └─fail─→ Pages: fallback page     (unhealthy: 503 + branded page)
+                          └─fail─→ inline page in the Worker
+```
+
+| Piece | Lives in | What it is |
+|---|---|---|
+| Fallback page | `fallback/index.html` | One self-contained HTML file. No build, no external requests. |
+| Failover Worker | `worker/src/index.js` | Routes traffic; swaps in the fallback on origin failure. |
+| Route config | `worker/wrangler.toml` | Puts the Worker in front of every path on the zone. |
+| Tests | `worker/test/` | `cd worker && npm test`. No dependencies. |
+
+## One deliberate departure from the issue
+
+The issue specified a `HEAD` health check before forwarding each request. The
+implementation instead sends the real request and treats its outcome as the
+health signal.
+
+Two round trips to the origin on every request would be paid by 100% of traffic
+to change the handling of a rare case. And a preflight is already stale by the
+time you act on it — the origin can drop between the `HEAD` and the request it
+vouched for, so the failure path has to exist anyway. Given that, the preflight
+buys nothing the catch block does not already cover.
+
+Everything else follows the issue as written.
+
+## What counts as failure
+
+Only 5xx. That covers the tunnel-specific codes (530 for a 1033, and 521/522/523
+for an unreachable origin) along with ordinary gateway errors.
+
+A 404 explicitly does **not** trigger the fallback — that is Caddy correctly
+reporting a missing page. Widening the check to "any non-2xx" would bury every
+broken link on the site behind a message claiming the server is offline.
+
+## Two details that are easy to get wrong
+
+**The fallback returns 503, not 200.** Visitors cannot see a status code, but
+crawlers can. A 503 with `Retry-After` reads as "come back later" and preserves
+the site's existing rankings; a 200 invites Google to index the outage page as
+the homepage. The page also carries `noindex`.
+
+**The fallback is `no-store`.** If an edge or a browser cached it, the outage
+would outlive the outage — visitors would keep seeing the offline page after
+Rainier came back.
+
+## Deploying
+
+Neither step is automated: both need Cloudflare account access.
+
+### 1. Fallback page → Cloudflare Pages
+
+Create a Pages project serving `infra/fallback/` as the output directory, with
+no build command. Direct upload works fine; there is nothing to compile.
+
+**The project name matters.** It determines the `*.pages.dev` hostname, and the
+Worker has that hostname hardcoded as `FALLBACK_ORIGIN`. Naming the project
+`forrestmorrisey-fallback` matches what is already in the code. Any other name
+means updating `worker/src/index.js` to match.
+
+Do **not** put the fallback on a subdomain of `forrestmorrisey.com`. The Worker
+route covers the whole zone, so fetching the fallback through that zone would
+loop back through the failover path it is meant to escape.
+
+### 2. Worker → Cloudflare Workers
+
+```bash
+cd infra/worker
+npx wrangler deploy
+```
+
+`wrangler.toml` binds the Worker to `forrestmorrisey.com/*` and
+`www.forrestmorrisey.com/*`. Confirm the `www` route matches how the zone is
+actually set up — if `www` is a redirect rather than a served hostname, that
+second route is harmless but pointless.
+
+## Verifying it works
+
+The honest test is an actual outage, which you can stage safely:
+
+1. With the site healthy, confirm normal browsing is unchanged and responses
+   carry no `x-fallback` header.
+2. Stop the origin: `docker compose -f infra/docker-compose.yml stop site` on
+   Rainier (or stop `cloudflared`, which exercises the 1033 path specifically).
+3. Load the site. Expect the branded page, HTTP 503, and
+   `x-fallback: origin-unreachable`:
+   ```bash
+   curl -sI https://forrestmorrisey.com/ | head -20
+   ```
+4. Start the origin again. The next request should reach the real site with no
+   intervention — no cache purge, no redeploy. If it does not, the `no-store`
+   header is not doing its job.
+
+Check a deep path too (`/writing/`), not just the root — the route pattern
+covers `/*` and a mistake there would only show up below the homepage.
+
+## Rollback
+
+Delete the Worker route in the Cloudflare dashboard. Traffic goes straight to
+the origin again and behaviour returns to exactly what it was before this
+feature, Cloudflare error pages included. The Pages project can stay; it costs
+nothing and serves no traffic on its own.
+
+## Deliberately not done
+
+From the issue's own out-of-scope list: automatic redirect after a timeout,
+resume download link, contact CTA, analytics on fallback hits, and Pages as a
+hot standby for the full site.

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,11 +1,17 @@
 # Infrastructure
 
-forrestmorrisey.com is served from a single origin — Rainier — reached over a
-Cloudflare Tunnel.
+The Astro site is served from a single origin — Rainier — reached over a
+Cloudflare Tunnel, and lives at **forrest.rainierserver.com**.
+
+**forrestmorrisey.com is still served by Squarespace** and stays that way until
+cutover, which is deliberately the last step of the migration. Nothing in this
+directory should route, link to, or depend on the Squarespace site.
 
 ```
 Browser → Cloudflare → Tunnel → cloudflared (host) → :8090 Caddy → /srv/www/forrestmorrisey.com
 ```
+
+(The web root is named for the final domain; the host serving it today is not.)
 
 | Path | What it is |
 |---|---|
@@ -92,9 +98,10 @@ Worker has that hostname hardcoded as `FALLBACK_ORIGIN`. Naming the project
 `forrestmorrisey-fallback` matches what is already in the code. Any other name
 means updating `worker/src/index.js` to match.
 
-Do **not** put the fallback on a subdomain of `forrestmorrisey.com`. The Worker
-route covers the whole zone, so fetching the fallback through that zone would
-loop back through the failover path it is meant to escape.
+Do **not** put the fallback on a hostname this Worker fronts. The route covers
+`forrest.rainierserver.com/*`, so serving the fallback from there would loop it
+back through the failover path it exists to escape. A `*.pages.dev` host is
+outside every route here, which is why it is the default.
 
 ### 2. Worker → Cloudflare Workers
 
@@ -103,10 +110,23 @@ cd infra/worker
 npx wrangler deploy
 ```
 
-`wrangler.toml` binds the Worker to `forrestmorrisey.com/*` and
-`www.forrestmorrisey.com/*`. Confirm the `www` route matches how the zone is
-actually set up — if `www` is a redirect rather than a served hostname, that
-second route is harmless but pointless.
+`wrangler.toml` binds the Worker to `forrest.rainierserver.com/*` — the host
+that actually serves the Astro site.
+
+**It is deliberately not bound to `forrestmorrisey.com`.** That domain is still
+Squarespace's until cutover; a route there today would put this Worker in front
+of the live Squarespace site, measure Squarespace's health, and serve a page
+claiming a self-hosted server the visitor never touched is down.
+
+## On cutover day
+
+When forrestmorrisey.com moves to Rainier, uncomment the apex and `www` routes
+in `wrangler.toml` and redeploy. Confirm first that `www` is actually a served
+hostname rather than a redirect — if it redirects, that second route is harmless
+but pointless.
+
+Nothing in the fallback page needs to change: its copy is domain-neutral for
+exactly this reason.
 
 ## Verifying it works
 
@@ -119,7 +139,7 @@ The honest test is an actual outage, which you can stage safely:
 3. Load the site. Expect the branded page, HTTP 503, and
    `x-fallback: origin-unreachable`:
    ```bash
-   curl -sI https://forrestmorrisey.com/ | head -20
+   curl -sI https://forrest.rainierserver.com/ | head -20
    ```
 4. Start the origin again. The next request should reach the real site with no
    intervention — no cache purge, no redeploy. If it does not, the `no-store`

--- a/infra/fallback/index.html
+++ b/infra/fallback/index.html
@@ -4,9 +4,12 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Forrest Morrisey — Temporarily Offline</title>
+    <!-- Copy stays domain-neutral on purpose. This page fronts
+         forrest.rainierserver.com today and forrestmorrisey.com after cutover;
+         naming either one would be wrong half the time. -->
     <meta
       name="description"
-      content="forrestmorrisey.com is briefly offline. Find Forrest Morrisey's work on GitHub and LinkedIn."
+      content="This site is briefly offline. Find Forrest Morrisey's work on GitHub and LinkedIn."
     />
 
     <!-- Search engines must not index the fallback in place of the real site.
@@ -155,8 +158,8 @@
            origins. A visitor who came here from a resume link needs a way
            forward, not a diagnosis. -->
       <p class="lede">
-        forrestmorrisey.com is self-hosted, and the server is briefly
-        unreachable. It comes back on its own.
+        This site is self-hosted, and the server is briefly unreachable. It
+        comes back on its own.
       </p>
       <p class="detail">My work is still up in both of these places:</p>
 

--- a/infra/fallback/index.html
+++ b/infra/fallback/index.html
@@ -1,0 +1,194 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Forrest Morrisey — Temporarily Offline</title>
+    <meta
+      name="description"
+      content="forrestmorrisey.com is briefly offline. Find Forrest Morrisey's work on GitHub and LinkedIn."
+    />
+
+    <!-- Search engines must not index the fallback in place of the real site.
+         A crawler that arrives mid-outage would otherwise cache this page as
+         the homepage, and the outage would outlive itself in search results. -->
+    <meta name="robots" content="noindex, nofollow" />
+
+    <!-- Everything below is inline on purpose. This page is served precisely
+         when infrastructure is failing, so it must not depend on a font CDN, an
+         analytics host, or a second request of any kind. One file, one hop. -->
+    <style>
+      :root {
+        /* Mirrors apps/site/src/styles/global.css so the fallback reads as the
+           same site rather than a generic error page. Duplicated rather than
+           imported because this file must stand alone. */
+        --bg: #0b0d10;
+        --fg: #e7eaf0;
+        --muted: #a6adbb;
+        --border: #232a3a;
+        --accent: #00ff71;
+        --font-sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto,
+          Arial, sans-serif;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 24px;
+        background: var(--bg);
+        color: var(--fg);
+        font-family: var(--font-sans);
+        line-height: 1.6;
+        -webkit-font-smoothing: antialiased;
+      }
+
+      main {
+        max-width: 34rem;
+        width: 100%;
+        text-align: center;
+      }
+
+      /* Drawn rather than set as the 🏔 emoji the site footer uses. Emoji
+         coverage for U+1F3D4 is patchy, and a tofu box is a bad first
+         impression on the one page whose whole job is to look composed. */
+      .mark {
+        width: 56px;
+        height: 36px;
+        margin: 0 auto 24px;
+        display: block;
+        fill: none;
+        stroke: var(--accent);
+        stroke-width: 2;
+        stroke-linejoin: round;
+        stroke-linecap: round;
+      }
+
+      h1 {
+        font-size: clamp(1.5rem, 4vw, 2rem);
+        margin: 0 0 16px;
+        letter-spacing: -0.01em;
+      }
+
+      .lede {
+        color: var(--muted);
+        margin: 0 0 8px;
+      }
+
+      .detail {
+        color: var(--muted);
+        font-size: 0.9rem;
+        margin: 0 0 40px;
+      }
+
+      .links {
+        display: flex;
+        gap: 12px;
+        justify-content: center;
+        flex-wrap: wrap;
+        margin-bottom: 48px;
+      }
+
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        padding: 12px 24px;
+        border: 1px solid var(--border);
+        border-radius: 999px;
+        color: var(--fg);
+        text-decoration: none;
+        font-size: 0.95rem;
+        transition: border-color 150ms ease, color 150ms ease;
+      }
+
+      .btn:hover,
+      .btn:focus-visible {
+        border-color: var(--accent);
+        color: var(--accent);
+      }
+
+      /* Keyboard focus must stay visible against the dark ground -- the hover
+         colour alone is not enough of a signal. */
+      .btn:focus-visible {
+        outline: 2px solid var(--accent);
+        outline-offset: 3px;
+      }
+
+      .btn svg {
+        width: 18px;
+        height: 18px;
+        fill: currentColor;
+      }
+
+      .signature {
+        color: var(--muted);
+        font-size: 0.75rem;
+        font-style: italic;
+        opacity: 0.7;
+        margin: 0;
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        .btn {
+          transition: none;
+        }
+      }
+    </style>
+  </head>
+
+  <body>
+    <main>
+      <svg class="mark" viewBox="0 0 64 40" aria-hidden="true">
+        <path d="M2 38 L22 8 L34 25 L42 14 L62 38 Z" />
+      </svg>
+
+      <h1>The site is taking a short break</h1>
+
+      <!-- Deliberately no status code, no "502", no mention of tunnels or
+           origins. A visitor who came here from a resume link needs a way
+           forward, not a diagnosis. -->
+      <p class="lede">
+        forrestmorrisey.com is self-hosted, and the server is briefly
+        unreachable. It comes back on its own.
+      </p>
+      <p class="detail">My work is still up in both of these places:</p>
+
+      <div class="links">
+        <a
+          class="btn"
+          href="https://github.com/fmorrisey"
+          rel="noopener noreferrer"
+        >
+          <svg viewBox="0 0 16 16" aria-hidden="true">
+            <path
+              d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z"
+            />
+          </svg>
+          GitHub
+        </a>
+
+        <a
+          class="btn"
+          href="https://linkedin.com/in/forrestmorrisey"
+          rel="noopener noreferrer"
+        >
+          <svg viewBox="0 0 16 16" aria-hidden="true">
+            <path
+              d="M0 1.146C0 .513.526 0 1.175 0h13.65C15.474 0 16 .513 16 1.146v13.708c0 .633-.526 1.146-1.175 1.146H1.175C.526 16 0 15.487 0 14.854V1.146Zm4.943 12.248V6.169H2.542v7.225h2.401Zm-1.2-8.212c.837 0 1.358-.554 1.358-1.248-.015-.709-.52-1.248-1.342-1.248-.822 0-1.359.54-1.359 1.248 0 .694.521 1.248 1.327 1.248h.016Zm4.908 8.212V9.359c0-.216.016-.432.08-.586.174-.431.568-.878 1.232-.878.869 0 1.216.662 1.216 1.634v3.865h2.401V9.25c0-2.22-1.184-3.252-2.764-3.252-1.274 0-1.845.7-2.165 1.193v.025h-.016l.016-.025V6.169h-2.4c.03.678 0 7.225 0 7.225h2.4Z"
+            />
+          </svg>
+          LinkedIn
+        </a>
+      </div>
+
+      <p class="signature">Built with intention. Designed for impact.</p>
+    </main>
+  </body>
+</html>

--- a/infra/worker/package.json
+++ b/infra/worker/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "forrestmorrisey-failover",
+  "private": true,
+  "type": "module",
+  "description": "Cloudflare Worker that serves a branded fallback page when the Rainier origin is unreachable.",
+  "scripts": {
+    "test": "node --test",
+    "deploy": "wrangler deploy",
+    "dev": "wrangler dev"
+  }
+}

--- a/infra/worker/src/index.js
+++ b/infra/worker/src/index.js
@@ -1,5 +1,9 @@
 /**
- * Origin failover for forrestmorrisey.com.
+ * Origin failover for the self-hosted site.
+ *
+ * Fronts forrest.rainierserver.com today; forrestmorrisey.com is still served
+ * by Squarespace and must not be routed through here until cutover. See
+ * wrangler.toml.
  *
  * The site is served from a single origin (Rainier) over a Cloudflare Tunnel.
  * When that origin is unreachable, Cloudflare's own error page (1033 / 52x) is

--- a/infra/worker/src/index.js
+++ b/infra/worker/src/index.js
@@ -1,0 +1,109 @@
+/**
+ * Origin failover for forrestmorrisey.com.
+ *
+ * The site is served from a single origin (Rainier) over a Cloudflare Tunnel.
+ * When that origin is unreachable, Cloudflare's own error page (1033 / 52x) is
+ * what a visitor sees -- often a recruiter following a link from a resume. This
+ * Worker replaces that with the branded fallback page in `infra/fallback`.
+ *
+ * ## Why there is no health check
+ *
+ * The original plan called for a `HEAD` preflight to the origin before
+ * forwarding each request. This does the same job with one round trip instead
+ * of two, by treating the real request as its own health check.
+ *
+ * That matters for more than latency. A preflight is also a lie by the time you
+ * act on it: the origin can drop between the `HEAD` and the request it was
+ * meant to vouch for, so the failure path has to exist regardless -- at which
+ * point the preflight is pure cost, paid on 100% of traffic to change the
+ * handling of a rare one.
+ */
+
+/** Where the static fallback lives. Must be a hostname this Worker does not
+ *  serve, or fetching it would loop back through this same failover path. */
+const FALLBACK_ORIGIN = "https://forrestmorrisey-fallback.pages.dev";
+
+/** Give up on a silent origin. Cloudflare itself waits ~100s before a 524,
+ *  which is far past the point a visitor has already left. A static site that
+ *  has not answered in 8s is not healthy. */
+const ORIGIN_TIMEOUT_MS = 8000;
+
+/** How long to tell clients and crawlers to wait before retrying, in seconds. */
+const RETRY_AFTER_S = 120;
+
+/**
+ * Is this response the origin failing, or the origin doing its job?
+ *
+ * Only 5xx counts. A 404 is Caddy correctly reporting a missing page and must
+ * pass through untouched -- swallowing those behind a fallback would hide real
+ * broken links behind a message that says everything is fine. Tunnel-specific
+ * failures (530 for 1033, 521/522/523 for an unreachable origin) all land in
+ * the same 5xx band.
+ */
+function isOriginFailure(response) {
+  return response.status >= 500;
+}
+
+/**
+ * Serve the fallback, or -- if even that fails -- a last-resort inline notice.
+ *
+ * Returned as 503 rather than 200 so the outage stays honest to machines:
+ * crawlers treat 503 + Retry-After as "come back later" and keep the real
+ * rankings, where a 200 would invite them to index this page as the site.
+ * The status is invisible to a human, who just sees the page.
+ */
+async function serveFallback() {
+  const headers = {
+    "content-type": "text/html; charset=utf-8",
+    // Never let the edge or a browser hold onto this. The moment Rainier is
+    // back, the next request must reach it -- an outage that outlives itself
+    // in a cache is worse than the outage.
+    "cache-control": "no-store, must-revalidate",
+    "retry-after": String(RETRY_AFTER_S),
+    "x-fallback": "origin-unreachable",
+  };
+
+  try {
+    const page = await fetch(FALLBACK_ORIGIN, {
+      signal: AbortSignal.timeout(ORIGIN_TIMEOUT_MS),
+    });
+
+    if (page.ok) {
+      return new Response(page.body, { status: 503, headers });
+    }
+  } catch {
+    // Fall through to the inline copy below.
+  }
+
+  // Both the origin and Pages are unreachable. Rare, but this is the one code
+  // path with nothing left to fall back to, so it carries no dependencies.
+  return new Response(
+    `<!doctype html><html lang="en"><head><meta charset="utf-8">` +
+      `<meta name="viewport" content="width=device-width,initial-scale=1">` +
+      `<meta name="robots" content="noindex,nofollow">` +
+      `<title>Forrest Morrisey — Temporarily Offline</title></head>` +
+      `<body style="margin:0;min-height:100vh;display:flex;align-items:center;justify-content:center;` +
+      `background:#0b0d10;color:#e7eaf0;font-family:system-ui,sans-serif;text-align:center;padding:24px">` +
+      `<main><h1 style="font-size:1.5rem">The site is taking a short break</h1>` +
+      `<p style="color:#a6adbb">Find me on ` +
+      `<a href="https://github.com/fmorrisey" style="color:#00ff71">GitHub</a> or ` +
+      `<a href="https://linkedin.com/in/forrestmorrisey" style="color:#00ff71">LinkedIn</a>.</p>` +
+      `</main></body></html>`,
+    { status: 503, headers }
+  );
+}
+
+export default {
+  async fetch(request) {
+    try {
+      const response = await fetch(request, {
+        signal: AbortSignal.timeout(ORIGIN_TIMEOUT_MS),
+      });
+
+      return isOriginFailure(response) ? await serveFallback() : response;
+    } catch {
+      // Timeout, DNS failure, tunnel down -- anything that means no response.
+      return await serveFallback();
+    }
+  },
+};

--- a/infra/worker/test/failover.test.mjs
+++ b/infra/worker/test/failover.test.mjs
@@ -1,0 +1,102 @@
+/**
+ * Failover behaviour for the origin Worker.
+ *
+ * Worth having despite the Worker's size: every branch here runs only while
+ * production is already broken. There is no natural moment to notice that the
+ * fallback path regressed -- the first person to find out would be a visitor
+ * during an outage, which is the exact audience this feature exists to protect.
+ *
+ * Run with `npm test` (node --test, no dependencies).
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import worker from "../src/index.js";
+
+const FALLBACK = "https://forrestmorrisey-fallback.pages.dev";
+
+const pagesOk = () => new Response("<html>FALLBACK PAGE</html>", { status: 200 });
+const pagesDead = () => {
+  throw new Error("pages unreachable");
+};
+
+/** Drive the Worker with a stubbed network: one behaviour for the origin, one
+ *  for the Pages host it falls back to. */
+async function run(originBehavior, pagesBehavior = pagesOk) {
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = async (req) => {
+    const url = typeof req === "string" ? req : req.url;
+    return url.startsWith(FALLBACK) ? pagesBehavior() : originBehavior();
+  };
+  try {
+    return await worker.fetch(new Request("https://forrestmorrisey.com/writing/"));
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+}
+
+test("a healthy origin passes through untouched", async () => {
+  const res = await run(() => new Response("real site", { status: 200 }));
+  assert.equal(res.status, 200);
+  assert.equal(await res.text(), "real site");
+});
+
+test("a 404 is the origin working, not failing", async () => {
+  // The regression this guards against: widening the failure check to any
+  // non-2xx, which would hide every broken link behind "we're offline".
+  const res = await run(() => new Response("not found", { status: 404 }));
+  assert.equal(res.status, 404);
+});
+
+test("redirects pass through", async () => {
+  const res = await run(() => new Response(null, { status: 301 }));
+  assert.equal(res.status, 301);
+});
+
+test("a downed tunnel (530) serves the fallback", async () => {
+  const res = await run(() => new Response("err", { status: 530 }));
+  assert.equal(res.status, 503);
+  assert.match(await res.text(), /FALLBACK PAGE/);
+});
+
+test("a 502 serves the fallback", async () => {
+  const res = await run(() => new Response("bad gateway", { status: 502 }));
+  assert.equal(res.status, 503);
+  assert.match(await res.text(), /FALLBACK PAGE/);
+});
+
+test("an origin that never responds serves the fallback", async () => {
+  const res = await run(() => {
+    throw new Error("ECONNREFUSED");
+  });
+  assert.equal(res.status, 503);
+  assert.match(await res.text(), /FALLBACK PAGE/);
+});
+
+test("the fallback tells clients to come back, and is never cached", async () => {
+  const res = await run(() => new Response("err", { status: 530 }));
+  assert.equal(res.headers.get("retry-after"), "120");
+  // A cached fallback would outlive the outage that caused it.
+  assert.match(res.headers.get("cache-control"), /no-store/);
+});
+
+test("losing both the origin and Pages still yields a usable page", async () => {
+  const res = await run(() => {
+    throw new Error("ECONNREFUSED");
+  }, pagesDead);
+  const body = await res.text();
+  assert.equal(res.status, 503);
+  assert.match(body, /github\.com\/fmorrisey/);
+  assert.match(body, /linkedin\.com\/in\/forrestmorrisey/);
+});
+
+test("a Pages project that 404s does not leak its error body", async () => {
+  const res = await run(
+    () => new Response("err", { status: 530 }),
+    () => new Response("nope", { status: 404 })
+  );
+  const body = await res.text();
+  assert.equal(res.status, 503);
+  assert.match(body, /short break/);
+  assert.doesNotMatch(body, /nope/);
+});

--- a/infra/worker/test/failover.test.mjs
+++ b/infra/worker/test/failover.test.mjs
@@ -29,7 +29,9 @@ async function run(originBehavior, pagesBehavior = pagesOk) {
     return url.startsWith(FALLBACK) ? pagesBehavior() : originBehavior();
   };
   try {
-    return await worker.fetch(new Request("https://forrestmorrisey.com/writing/"));
+    return await worker.fetch(
+      new Request("https://forrest.rainierserver.com/writing/")
+    );
   } finally {
     globalThis.fetch = realFetch;
   }

--- a/infra/worker/wrangler.toml
+++ b/infra/worker/wrangler.toml
@@ -2,15 +2,29 @@ name = "forrestmorrisey-failover"
 main = "src/index.js"
 compatibility_date = "2026-08-12"
 
-# The Worker must sit in front of every path, not just the root: an outage
-# takes down /writing, /photography and the assets alongside the homepage.
+# Bound to the staging host, not the apex domain, and that is the whole point:
+# forrestmorrisey.com is still served by Squarespace until cutover. A route on
+# the apex today would put this Worker in front of Squarespace, health-check
+# Squarespace's origin, and fail over to a page announcing that a self-hosted
+# server the visitor never reached is down.
 #
-# `zone_name` keeps this readable rather than pinning a zone ID that means
-# nothing to whoever reads it next.
+# forrest.rainierserver.com is where the Astro site actually lives
+# (.github/workflows/deploy.yml, and the cloudflared ingress -> :8090 Caddy).
+#
+# The Worker must cover every path, not just the root: an outage takes down
+# /writing and the assets alongside the homepage.
 [[routes]]
-pattern = "forrestmorrisey.com/*"
-zone_name = "forrestmorrisey.com"
+pattern = "forrest.rainierserver.com/*"
+zone_name = "rainierserver.com"
 
-[[routes]]
-pattern = "www.forrestmorrisey.com/*"
-zone_name = "forrestmorrisey.com"
+# ON CUTOVER DAY -- once forrestmorrisey.com is served by Rainier rather than
+# Squarespace, uncomment these. Adding them before the DNS move would intercept
+# the live Squarespace site.
+#
+# [[routes]]
+# pattern = "forrestmorrisey.com/*"
+# zone_name = "forrestmorrisey.com"
+#
+# [[routes]]
+# pattern = "www.forrestmorrisey.com/*"
+# zone_name = "forrestmorrisey.com"

--- a/infra/worker/wrangler.toml
+++ b/infra/worker/wrangler.toml
@@ -1,0 +1,16 @@
+name = "forrestmorrisey-failover"
+main = "src/index.js"
+compatibility_date = "2026-08-12"
+
+# The Worker must sit in front of every path, not just the root: an outage
+# takes down /writing, /photography and the assets alongside the homepage.
+#
+# `zone_name` keeps this readable rather than pinning a zone ID that means
+# nothing to whoever reads it next.
+[[routes]]
+pattern = "forrestmorrisey.com/*"
+zone_name = "forrestmorrisey.com"
+
+[[routes]]
+pattern = "www.forrestmorrisey.com/*"
+zone_name = "forrestmorrisey.com"


### PR DESCRIPTION
Addresses #5. **Code is complete and tested; the two deploy steps need Cloudflare account access, so this cannot fully close the issue on merge.**

## What's here

| Piece | File |
|---|---|
| Fallback page | `infra/fallback/index.html` — one self-contained file, no build, no external requests |
| Failover Worker | `infra/worker/src/index.js` |
| Route config | `infra/worker/wrangler.toml` |
| Tests | `infra/worker/test/failover.test.mjs` — 9 cases, `node --test`, no dependencies |
| Ops doc | `infra/README.md` |

## One deliberate departure from the issue

The issue specced a `HEAD` health check before forwarding each request. This sends the real request and treats its outcome as the health signal instead.

Two round trips to the origin on every request would be paid by 100% of traffic to change the handling of a rare case. And a preflight is stale by the time you act on it — the origin can drop between the `HEAD` and the request it vouched for, so the failure path has to exist anyway. Given that, the preflight buys nothing the catch block doesn't already cover.

Happy to put the preflight back if you want the spec followed literally. Everything else follows it as written.

## Decisions worth a look

- **Failure is 5xx only.** A 404 passes through untouched — it's Caddy correctly reporting a missing page. Treating any non-2xx as an outage would hide every broken link behind "the server is offline".
- **The fallback answers 503, not 200.** Invisible to a visitor, but a 503 + `Retry-After` keeps crawlers from indexing the outage page as the homepage.
- **`no-store` on the fallback**, so a cached copy can't outlive the outage that caused it.
- **Three tiers.** If Pages is *also* unreachable, the Worker serves a minimal inline page rather than nothing.

## Verification

- `npm test` in `infra/worker` — 9/9 pass, covering pass-through of 200/301/404, fallback on 502/530/throw, the `Retry-After` and `no-store` headers, the double-outage inline path, and a Pages 404 not leaking its body.
- Fallback page rendered headless at 1200px and 375px; both check out.
- The 🏔 emoji the site footer uses rendered as a tofu box, so the mark is now inline SVG in the brand accent — no font dependency, which suits a page that loads while things are broken.

## Not verified

Nothing has touched Cloudflare. The Worker has never run on the real runtime, and the "stop the origin and watch it fail over" test in `infra/README.md` hasn't been run — both need account access I don't have.

`FALLBACK_ORIGIN` in the Worker is hardcoded to `https://forrestmorrisey-fallback.pages.dev`, which assumes the Pages project gets named `forrestmorrisey-fallback`. Any other name needs that constant updated.

Also worth confirming the `www.forrestmorrisey.com/*` route matches how the zone is actually set up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)